### PR TITLE
Improve investment data customization

### DIFF
--- a/pubgminvest.css
+++ b/pubgminvest.css
@@ -1,0 +1,82 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f8f8fa;
+    margin: 0;
+    padding: 0;
+}
+
+header {
+    background-color: #333;
+    color: #fff;
+    text-align: center;
+    padding: 20px 0;
+}
+
+.search-bar {
+    text-align: center;
+    margin: 20px 0;
+}
+
+.search-bar input {
+    width: 80%;
+    max-width: 400px;
+    padding: 10px;
+    font-size: 16px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+.section {
+    width: 90%;
+    max-width: 1200px;
+    margin: 20px auto;
+}
+
+.card-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+}
+
+.card {
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    padding: 15px;
+    width: 200px;
+    position: relative;
+}
+
+.card img {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+    border-radius: 4px;
+}
+
+.card h3 {
+    margin: 10px 0 5px;
+    font-size: 18px;
+}
+
+.card p {
+    margin: 4px 0;
+    font-size: 14px;
+}
+
+.id-label {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    background: rgba(0, 0, 0, 0.6);
+    color: #fff;
+    padding: 2px 6px;
+    font-size: 12px;
+    border-radius: 4px;
+}
+
+.chart {
+    width: 100%;
+    height: 60px;
+    margin-top: 10px;
+}

--- a/pubgminvest.html
+++ b/pubgminvest.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PUBGM 投资所</title>
+    <link rel="stylesheet" href="pubgminvest.css">
+</head>
+<body>
+    <header>
+        <h1>PUBGM 投资所</h1>
+    </header>
+    <main>
+        <div class="search-bar">
+            <input type="text" id="searchInput" placeholder="根据投资号码搜索枪械">
+        </div>
+        <section id="weapon-section" class="section">
+            <h2>枪械投资</h2>
+            <div id="weaponContainer" class="card-container"></div>
+        </section>
+        <section id="item-section" class="section">
+            <h2>变卖物投资</h2>
+            <div id="itemContainer" class="card-container"></div>
+        </section>
+    </main>
+    <!-- 如需修改投资数据，可在此处通过 script 标签定义 window.weaponInvestments
+         和 window.itemInvestments 变量，pubgminvest.js 会自动读取 -->
+    <script>
+        window.weaponInvestments = [
+            {
+                id: 'W001',
+                name: 'M416',
+                price: '¥500',
+                seller: '商家A',
+                image: 'pathtoyourimage1.png',
+                index: [100, 105, 102, 110, 120]
+            },
+            {
+                id: 'W002',
+                name: 'AKM',
+                price: '¥450',
+                seller: '商家B',
+                image: 'pathtoyourimage2.png',
+                index: [90, 92, 95, 99, 105]
+            }
+        ];
+
+        window.itemInvestments = [
+            {
+                id: 'I001',
+                name: '三级头盔',
+                price: '¥80',
+                seller: '商家C',
+                image: 'pathtoyourimage1.png',
+                index: [50, 55, 53, 60, 65]
+            },
+            {
+                id: 'I002',
+                name: '防弹衣',
+                price: '¥120',
+                seller: '商家D',
+                image: 'pathtoyourimage2.png',
+                index: [60, 62, 66, 70, 72]
+            }
+        ];
+    </script>
+    <script src="pubgminvest.js"></script>
+</body>
+</html>

--- a/pubgminvest.html
+++ b/pubgminvest.html
@@ -12,7 +12,7 @@
     </header>
     <main>
         <div class="search-bar">
-            <input type="text" id="searchInput" placeholder="根据投资号码搜索枪械">
+            <input type="text" id="searchInput" placeholder="根据投资号码搜索">
         </div>
         <section id="weapon-section" class="section">
             <h2>枪械投资</h2>
@@ -23,8 +23,11 @@
             <div id="itemContainer" class="card-container"></div>
         </section>
     </main>
-    <!-- 如需修改投资数据，可在此处通过 script 标签定义 window.weaponInvestments
-         和 window.itemInvestments 变量，pubgminvest.js 会自动读取 -->
+    <!--
+        如需修改投资数据，可在此处通过 script 标签定义
+        window.weaponInvestments 和 window.itemInvestments 变量，
+        pubgminvest.js 会自动读取这些值
+    -->
     <script>
         window.weaponInvestments = [
             {

--- a/pubgminvest.js
+++ b/pubgminvest.js
@@ -1,0 +1,142 @@
+// 管理员可在此处修改投资数据
+// 如果在 HTML 中通过 script 标签提前定义 window.weaponInvestments，
+// 这里会使用该自定义数据，否则使用默认值
+const weaponInvestments = window.weaponInvestments || [
+    {
+        id: 'W001',
+        name: 'M416',
+        price: '¥500',
+        seller: '商家A',
+        image: 'pathtoyourimage1.png',
+        index: [100, 105, 102, 110, 120]
+    },
+    {
+        id: 'W002',
+        name: 'AKM',
+        price: '¥450',
+        seller: '商家B',
+        image: 'pathtoyourimage2.png',
+        index: [90, 92, 95, 99, 105]
+    }
+];
+
+// 变卖物投资列表
+// 同理，可在 HTML 中定义 window.itemInvestments 覆盖默认值
+const itemInvestments = window.itemInvestments || [
+    {
+        id: 'I001',
+        name: '三级头盔',
+        price: '¥80',
+        seller: '商家C',
+        image: 'pathtoyourimage1.png',
+        index: [50, 55, 53, 60, 65]
+    },
+    {
+        id: 'I002',
+        name: '防弹衣',
+        price: '¥120',
+        seller: '商家D',
+        image: 'pathtoyourimage2.png',
+        index: [60, 62, 66, 70, 72]
+    }
+];
+
+function createCard(item) {
+    const card = document.createElement('div');
+    card.className = 'card';
+
+    const idLabel = document.createElement('div');
+    idLabel.className = 'id-label';
+    idLabel.textContent = item.id;
+
+    const img = document.createElement('img');
+    img.src = item.image;
+    img.alt = item.name;
+
+    const title = document.createElement('h3');
+    title.textContent = item.name;
+
+    const price = document.createElement('p');
+    price.textContent = '价格: ' + item.price;
+
+    const seller = document.createElement('p');
+    seller.textContent = '发货商家: ' + item.seller;
+
+    const canvas = document.createElement('canvas');
+    canvas.className = 'chart';
+
+    card.appendChild(idLabel);
+    card.appendChild(img);
+    card.appendChild(title);
+    card.appendChild(price);
+    card.appendChild(seller);
+    card.appendChild(canvas);
+    return card;
+}
+
+function drawLineChart(canvas, data) {
+    const ctx = canvas.getContext('2d');
+    const width = canvas.width = canvas.offsetWidth;
+    const height = canvas.height = canvas.offsetHeight;
+    const max = Math.max(...data);
+    const min = Math.min(...data);
+    const margin = 5; // 留一点边距绘制坐标轴
+
+    ctx.clearRect(0, 0, width, height);
+
+    // 绘制坐标轴（第一象限）
+    ctx.beginPath();
+    ctx.moveTo(margin, margin);
+    ctx.lineTo(margin, height - margin);
+    ctx.lineTo(width - margin, height - margin);
+    ctx.strokeStyle = '#666';
+    ctx.stroke();
+
+    // 绘制折线图
+    ctx.beginPath();
+    data.forEach((val, i) => {
+        const x = margin + (i / (data.length - 1)) * (width - 2 * margin);
+        const y = height - margin - ((val - min) / (max - min)) * (height - 2 * margin);
+        if (i === 0) {
+            ctx.moveTo(x, y);
+        } else {
+            ctx.lineTo(x, y);
+        }
+    });
+    ctx.strokeStyle = '#007bff';
+    ctx.stroke();
+}
+
+function renderWeapons(list) {
+    const container = document.getElementById('weaponContainer');
+    container.innerHTML = '';
+    list.forEach(item => {
+        const card = createCard(item);
+        container.appendChild(card);
+        const canvas = card.querySelector('canvas');
+        drawLineChart(canvas, item.index);
+    });
+}
+
+function renderItems(list) {
+    const container = document.getElementById('itemContainer');
+    container.innerHTML = '';
+    list.forEach(item => {
+        const card = createCard(item);
+        container.appendChild(card);
+        const canvas = card.querySelector('canvas');
+        drawLineChart(canvas, item.index);
+    });
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+    renderWeapons(weaponInvestments);
+    renderItems(itemInvestments);
+
+    const searchInput = document.getElementById('searchInput');
+    searchInput.addEventListener('input', () => {
+        const term = searchInput.value.trim().toLowerCase();
+        const filtered = weaponInvestments.filter(w => w.id.toLowerCase().includes(term));
+        renderWeapons(filtered);
+    });
+});

--- a/pubgminvest.js
+++ b/pubgminvest.js
@@ -1,6 +1,7 @@
 // 管理员可在此处修改投资数据
-// 如果在 HTML 中通过 script 标签提前定义 window.weaponInvestments，
-// 这里会使用该自定义数据，否则使用默认值
+// 如果希望在 HTML 中单独维护数据，可在页面的 <script> 标签中
+// 定义 window.weaponInvestments 和 window.itemInvestments 变量，
+// 本脚本会自动读取这些值。未定义时将使用下面的默认列表
 const weaponInvestments = window.weaponInvestments || [
     {
         id: 'W001',
@@ -21,7 +22,7 @@ const weaponInvestments = window.weaponInvestments || [
 ];
 
 // 变卖物投资列表
-// 同理，可在 HTML 中定义 window.itemInvestments 覆盖默认值
+// 如果页面中提供 window.itemInvestments，下面的数组会被覆盖
 const itemInvestments = window.itemInvestments || [
     {
         id: 'I001',
@@ -136,7 +137,10 @@ window.addEventListener('DOMContentLoaded', () => {
     const searchInput = document.getElementById('searchInput');
     searchInput.addEventListener('input', () => {
         const term = searchInput.value.trim().toLowerCase();
-        const filtered = weaponInvestments.filter(w => w.id.toLowerCase().includes(term));
-        renderWeapons(filtered);
+        // 根据投资号同时过滤枪械和变卖物
+        const filteredWeapons = weaponInvestments.filter(w => w.id.toLowerCase().includes(term));
+        const filteredItems = itemInvestments.filter(i => i.id.toLowerCase().includes(term));
+        renderWeapons(filteredWeapons);
+        renderItems(filteredItems);
     });
 });


### PR DESCRIPTION
## Summary
- allow defining investment data in HTML via `window.weaponInvestments` and `window.itemInvestments`
- document example usage in `pubgminvest.html`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6881a653172883229e5d964d70747449